### PR TITLE
Remove ember-breadcrumbs dependency

### DIFF
--- a/app/components/sc-breadcrumb.js
+++ b/app/components/sc-breadcrumb.js
@@ -1,0 +1,54 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+    router: null,
+    applicationController: null,
+
+    handlerInfos: function () {
+        return this.get('router').router.currentHandlerInfos;
+    }.property('applicationController.currentPath'),
+
+    pathNames: Ember.computed.mapBy('handlerInfos', 'name'),
+    controllers: Ember.computed.mapBy('handlerInfos', 'handler.controller'),
+
+    breadCrumbs: function () {
+        var controllers = this.get('controllers'),
+            defaultPaths = this.get('pathNames'),
+            breadCrumbs = [];
+
+        controllers.forEach(function (controller, index) {
+            var crumbs = controller.get('breadCrumbs') || [];
+            var singleCrumb = controller.get('breadCrumb');
+
+            if (!Ember.isBlank(singleCrumb)) {
+                crumbs.push({
+                    label: singleCrumb,
+                    path: controller.get('breadCrumbPath'),
+                    model: controller.get('breadCrumbModel'),
+                });
+            }
+
+            crumbs.forEach(function (crumb) {
+                breadCrumbs.addObject(Ember.Object.create({
+                    label: crumb.label,
+                    path: crumb.path || defaultPaths[index],
+                    model: crumb.model,
+                    linkable: !Ember.isNone(crumb.linkable) ? crumb.linkable : true,
+                    isCurrent: false
+                }));
+            });
+        });
+
+        var deepestCrumb = breadCrumbs.get('lastObject');
+        if (deepestCrumb) {
+            deepestCrumb.isCurrent = true;
+        }
+
+        return breadCrumbs;
+    }.property(
+        'controllers.@each.breadCrumbs',
+        'controllers.@each.breadCrumb',
+        'controllers.@each.breadCrumbPath',
+        'controllers.@each.breadCrumbModel',
+        'pathNames.[]')
+});

--- a/app/templates/-headbar.hbs
+++ b/app/templates/-headbar.hbs
@@ -53,7 +53,7 @@
                 {{currentRouteName}}
             </div>
             <div class="breadcrumb-links">
-                {{bread-crumbs}}
+                {{sc-breadcrumb}}
             </div>
         </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "broccoli-asset-rev": "^2.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "connect-restreamer": "^1.0.1",
-    "ember-breadcrumbs": "^0.1.1",
     "ember-cli": "^0.1.12",
     "ember-cli-6to5": "^3.0.0",
     "ember-cli-app-version": "0.3.1",


### PR DESCRIPTION
Added: Custom breadcrumbs component (same code as ember-breadcrumbs),
but integrated as a standard component.